### PR TITLE
Remove soon to be deprecated get_tensor()

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -21,4 +21,4 @@ if __name__ == '__main__':
     test = net.add_node(np.array([1.0, 0.0], dtype=np.float32))
     edge = net.connect(test[0], x[0])
     ans = net.contract(edge)
-    print(ans.get_tensor())
+    print(ans.tensor)


### PR DESCRIPTION
Thanks for using our library! We plan on deprecating `get_tensor()` soon in favor of just using `node.tensor`.